### PR TITLE
Add optional Apache Solr lexical search

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,7 @@
 SERVER_ADDR=127.0.0.1:8080
 QDRANT_URI=http://localhost:6334
+# Optional: set to enable lexical search via /api/search_lexical (see solr/README.md)
+# SOLR_URL=http://localhost:8983/solr/omop_concepts
 VECTORDB_DATA_PATH=sample_data.txt
 CORS_ORIGINS=http://localhost:5173
 PG__USER=postgres

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -29,3 +29,4 @@ tokio-pg-mapper = "0.2.0"
 tokio-pg-mapper-derive = "0.2.0"
 tokio-postgres = { version = "0.7.16", features = ["with-chrono-0_4"] }
 uuid = { version = "1.22.0", features = ["v4", "serde"] }
+form_urlencoded = "1.2.2"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -204,6 +204,108 @@ paths:
         '500':
           description: Internal server error
 
+  /api/search_lexical:
+    get:
+      summary: Lexical search for concepts
+      description: >
+        Perform keyword-based lexical search for medical concepts using Apache Solr.
+        Unlike the semantic search endpoints, this uses exact and fuzzy text matching
+        rather than vector similarity. Best for searching by exact concept codes
+        (e.g., ICD-10 codes), known concept names, or when semantic similarity is not desired.
+        Supports medical synonym expansion (e.g., MI -> myocardial infarction).
+        Returns 503 if Solr is not configured (SOLR_URL not set).
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query string for medical concepts
+          schema:
+            type: string
+          example: "E11.9"
+        - name: vocabulary_id
+          in: query
+          required: false
+          description: Filter results by vocabulary ID (e.g. SNOMED, ICD10CM, RxNorm). Supports multiple values as comma-separated string.
+          schema:
+            type: string
+          examples:
+            single:
+              value: "SNOMED"
+              summary: Single vocabulary filter
+            multiple_comma_separated:
+              value: "SNOMED,ICD10CM"
+              summary: Multiple vocabulary filters (comma-separated)
+        - name: exclude_vocabulary_id
+          in: query
+          required: false
+          description: Exclude results with specified vocabulary IDs using substring matching. Supports multiple values as comma-separated string. Case-insensitive.
+          schema:
+            type: string
+          examples:
+            single:
+              value: "ICD9CM"
+              summary: Exclude single vocabulary
+            substring_match:
+              value: "ICD"
+              summary: Exclude all vocabularies containing "ICD"
+        - name: standard_concept
+          in: query
+          required: false
+          description: Filter by standard concept status (S = standard, C = classification, None = non-standard)
+          schema:
+            type: string
+          example: "S"
+        - name: domain_id
+          in: query
+          required: false
+          description: Filter results by domain ID (e.g. Condition, Drug, Procedure). Supports multiple values as comma-separated string.
+          schema:
+            type: string
+          examples:
+            single:
+              value: "Condition"
+              summary: Single domain filter
+            multiple_comma_separated:
+              value: "Condition,Drug"
+              summary: Multiple domain filters (comma-separated)
+        - name: concept_class_id
+          in: query
+          required: false
+          description: Filter results by concept class ID (e.g. Disorder). Supports multiple values as comma-separated string.
+          schema:
+            type: string
+          examples:
+            single:
+              value: "Disorder"
+              summary: Single concept class filter
+            multiple_comma_separated:
+              value: "Disorder,Clinical Finding"
+              summary: Multiple concept class filters (comma-separated)
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of results to return (default 25)
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
+          example: 50
+      responses:
+        '200':
+          description: Successful lexical search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SearchResponse'
+        '400':
+          description: Bad request
+        '500':
+          description: Internal server error
+        '503':
+          description: Lexical search not available (Solr not configured)
+
   /api/concepts/{id}:
     get:
       summary: Get concept by ID

--- a/api/src/api.rs
+++ b/api/src/api.rs
@@ -236,6 +236,100 @@ async fn search_api(
     Ok(Json(search(parameters, state, CONCEPT_COLLECTION).await?))
 }
 
+#[get("/api/search_lexical")]
+pub async fn search_lexical(
+    parameters: Query<Parameters>,
+    state: Data<StateWrapper>,
+) -> Result<Json<Vec<SearchResponse>>, Error> {
+    let solr_client = state.solr_client.as_ref().ok_or_else(|| {
+        actix_web::error::ErrorServiceUnavailable(
+            "Lexical search is not available. Solr is not configured (set SOLR_URL to enable).",
+        )
+    })?;
+
+    let input = parameters.q.trim();
+    info!("Received lexical search request for {:?}", input);
+
+    let limit = parameters.limit.unwrap_or(25);
+
+    let filters = crate::solr::SolrFilters {
+        vocabulary_id: parameters.vocabulary_id.clone(),
+        exclude_vocabulary_id: parameters.exclude_vocabulary_id.clone(),
+        domain_id: parameters.domain_id.clone(),
+        concept_class_id: parameters.concept_class_id.clone(),
+        standard_concept: parameters.standard_concept.clone(),
+    };
+
+    let solr_docs = solr_client
+        .search(input, &filters, limit)
+        .await
+        .map_err(|e| actix_web::error::ErrorInternalServerError(e.to_string()))?;
+
+    let total = solr_docs.len().max(1) as f64;
+    let mut grouped: HashMap<String, (f64, Vec<Concept>)> = HashMap::new();
+
+    for (idx, doc) in solr_docs.iter().enumerate() {
+        let record_count = state
+            .concept_record_counts
+            .get(&doc.concept_id)
+            .copied()
+            .unwrap_or(doc.record_count);
+
+        let concept = Concept {
+            concept_id: doc.concept_id,
+            concept_name: doc.concept_name.clone(),
+            domain_id: doc.domain_id.clone(),
+            vocabulary_id: doc.vocabulary_id.clone(),
+            concept_class_id: doc.concept_class_id.clone(),
+            standard_concept: if doc.standard_concept.as_deref() == Some("") {
+                None
+            } else {
+                doc.standard_concept.clone()
+            },
+            concept_code: doc.concept_code.clone(),
+            invalid_reason: if doc.invalid_reason.as_deref() == Some("") {
+                None
+            } else {
+                doc.invalid_reason.clone()
+            },
+            valid_start_date: None,
+            valid_end_date: None,
+            record_count,
+        };
+
+        // Position-based score: first result = 1.0, last = near 0.0
+        let score = 1.0 - (idx as f64 / total);
+        let name_lower = concept.concept_name.to_lowercase();
+
+        if let Some((existing_score, concepts)) = grouped.get_mut(&name_lower) {
+            if score > *existing_score {
+                *existing_score = score;
+            }
+            concepts.push(concept);
+        } else {
+            grouped.insert(name_lower, (score, vec![concept]));
+        }
+    }
+
+    let mut responses: Vec<SearchResponse> = grouped
+        .into_iter()
+        .map(|(name_lower, (score, concepts))| SearchResponse {
+            concept_name: concepts[0].concept_name.clone(),
+            concept_name_lower: name_lower,
+            score: Some(score),
+            concepts,
+        })
+        .collect();
+
+    responses.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(Json(responses))
+}
+
 async fn search(
     parameters: Query<Parameters>,
     state: Data<StateWrapper>,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -20,6 +20,7 @@ pub struct Configs {
     pub pg: deadpool_postgres::Config,
     pub cache_max_capacity: u64,
     pub cache_ttl_days: u64,
+    pub solr_url: Option<String>,
 }
 
 impl Default for Configs {
@@ -32,6 +33,7 @@ impl Default for Configs {
             pg: deadpool_postgres::Config::default(),
             cache_max_capacity: 64,
             cache_ttl_days: 21,
+            solr_url: None,
         }
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -7,11 +7,12 @@ mod embeddings;
 mod errors;
 mod umls;
 mod utils;
+mod solr;
 mod validation;
 
 use crate::api::{
     analyze_concept_set, get_concept_by_id, get_concept_definition, get_concept_expand,
-    get_concept_phoebe, get_concept_relationships, search_api, search_standard,
+    get_concept_phoebe, get_concept_relationships, search_api, search_lexical, search_standard,
 };
 use crate::config::Configs;
 use crate::domain::{Concept, ExpandCacheKey, ExpandResponse};
@@ -36,6 +37,7 @@ struct StateWrapper {
     concept_record_counts: HashMap<i32, i64>,
     pg_pool: Pool,
     qdrant_client: Qdrant,
+    solr_client: Option<crate::solr::SolrClient>,
     expand_cache: Cache<ExpandCacheKey, ExpandResponse>,
     children_cache: Cache<i32, Vec<Concept>>,
     parents_cache: Cache<i32, Vec<Concept>>,
@@ -71,6 +73,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors)
             .service(search_standard)
             .service(search_api)
+            .service(search_lexical)
             .service(get_concept_by_id)
             .service(get_concept_relationships)
             .service(get_concept_definition)
@@ -107,6 +110,20 @@ async fn create_state(config: &Configs) -> anyhow::Result<Data<StateWrapper>> {
         .await
         .context("Qdrant health check failed")?;
 
+    let solr_client = if let Some(solr_url) = &config.solr_url {
+        info!("Initializing Solr client (url: {})", solr_url);
+        let client = crate::solr::SolrClient::new(solr_url)
+            .context("Failed to build Solr client")?;
+        client
+            .health_check()
+            .await
+            .context("Solr health check failed - is Solr running?")?;
+        Some(client)
+    } else {
+        info!("Solr not configured (SOLR_URL not set), lexical search disabled");
+        None
+    };
+
     let concept_index = load_concept_index(&config.vectordb_data_path)?;
     let concept_record_counts = load_concept_record_counts()?;
 
@@ -135,6 +152,7 @@ async fn create_state(config: &Configs) -> anyhow::Result<Data<StateWrapper>> {
         concept_record_counts,
         pg_pool,
         qdrant_client,
+        solr_client,
         expand_cache,
         children_cache,
         parents_cache,

--- a/api/src/solr.rs
+++ b/api/src/solr.rs
@@ -1,0 +1,142 @@
+use anyhow::{Context, Result};
+use log::info;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct SolrResponse {
+    response: SolrResponseBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct SolrResponseBody {
+    #[serde(rename = "numFound")]
+    num_found: u64,
+    docs: Vec<SolrDoc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SolrDoc {
+    pub concept_id: i32,
+    pub concept_name: String,
+    pub domain_id: String,
+    pub vocabulary_id: String,
+    pub concept_class_id: String,
+    pub standard_concept: Option<String>,
+    pub concept_code: String,
+    pub invalid_reason: Option<String>,
+    #[serde(default)]
+    pub record_count: i64,
+}
+
+pub struct SolrFilters {
+    pub vocabulary_id: Option<Vec<String>>,
+    pub exclude_vocabulary_id: Option<Vec<String>>,
+    pub domain_id: Option<Vec<String>>,
+    pub concept_class_id: Option<Vec<String>>,
+    pub standard_concept: Option<String>,
+}
+
+pub struct SolrClient {
+    client: Client,
+    base_url: String,
+}
+
+impl SolrClient {
+    pub fn new(solr_url: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .context("Failed to build Solr HTTP client")?;
+
+        Ok(Self {
+            client,
+            base_url: solr_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    pub async fn health_check(&self) -> Result<()> {
+        let url = format!("{}/admin/ping", self.base_url);
+        self.client
+            .get(&url)
+            .send()
+            .await
+            .context("Solr health check failed")?
+            .error_for_status()
+            .context("Solr health check returned error status")?;
+        Ok(())
+    }
+
+    pub async fn search(&self, query: &str, filters: &SolrFilters, limit: u64) -> Result<Vec<SolrDoc>> {
+        info!("Solr lexical search for: {:?}", query);
+
+        let mut params: Vec<(&str, String)> = vec![
+            ("q", query.to_string()),
+            ("rows", limit.to_string()),
+            ("wt", "json".to_string()),
+        ];
+
+        // Build filter queries
+        if let Some(vocab_ids) = &filters.vocabulary_id {
+            let fq = vocab_ids
+                .iter()
+                .map(|v| format!("\"{}\"", v))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            params.push(("fq", format!("vocabulary_id:({})", fq)));
+        }
+
+        if let Some(exclude_vocab_ids) = &filters.exclude_vocabulary_id {
+            for ev in exclude_vocab_ids {
+                params.push(("fq", format!("-vocabulary_id:\"{}\"", ev)));
+            }
+        }
+
+        if let Some(domain_ids) = &filters.domain_id {
+            let fq = domain_ids
+                .iter()
+                .map(|d| format!("\"{}\"", d))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            params.push(("fq", format!("domain_id:({})", fq)));
+        }
+
+        if let Some(class_ids) = &filters.concept_class_id {
+            let fq = class_ids
+                .iter()
+                .map(|c| format!("\"{}\"", c))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            params.push(("fq", format!("concept_class_id:({})", fq)));
+        }
+
+        if let Some(std) = &filters.standard_concept {
+            params.push(("fq", format!("standard_concept:\"{}\"", std)));
+        }
+
+        // Build URL with query parameters using form_urlencoded for proper encoding
+        let query_string: String = form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(params.iter().map(|(k, v)| (*k, v.as_str())))
+            .finish();
+        let url = format!("{}/select?{}", self.base_url, query_string);
+
+        let response: SolrResponse = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Solr query request failed")?
+            .error_for_status()
+            .context("Solr returned error status")?
+            .json()
+            .await
+            .context("Failed to deserialize Solr response")?;
+
+        info!(
+            "Solr returned {} results (of {} total)",
+            response.response.docs.len(),
+            response.response.num_found
+        );
+        Ok(response.response.docs)
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  solr:
+    image: solr:9.8
+    container_name: hecate-solr
+    ports:
+      - "8983:8983"
+    volumes:
+      - solr_data:/var/solr
+      - ./solr/configsets/omop_concepts:/opt/solr/server/solr/configsets/omop_concepts
+    command: >
+      bash -c "
+        precreate-core omop_concepts /opt/solr/server/solr/configsets/omop_concepts &&
+        solr-foreground
+      "
+    environment:
+      - SOLR_HEAP=2g
+    restart: unless-stopped
+
+volumes:
+  solr_data:

--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -1,0 +1,3 @@
+psycopg2-binary>=2.9
+requests>=2.31
+tqdm>=4.66

--- a/etl/solr_load.py
+++ b/etl/solr_load.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""ETL script to load OMOP vocabulary concepts from PostgreSQL into Apache Solr."""
+
+import os
+import sys
+import json
+import argparse
+from datetime import date, datetime
+
+import psycopg2
+import psycopg2.extras
+import requests
+from tqdm import tqdm
+
+SOLR_URL = os.environ.get("SOLR_URL", "http://localhost:8983/solr/omop_concepts")
+BATCH_SIZE = 5000
+
+
+def get_pg_connection():
+    """Create PostgreSQL connection using the same env vars as the Rust API."""
+    return psycopg2.connect(
+        host=os.environ.get("PG__HOST", "127.0.0.1"),
+        port=os.environ.get("PG__PORT", "5432"),
+        dbname=os.environ.get("PG__DBNAME", "hecate"),
+        user=os.environ.get("PG__USER", "postgres"),
+        password=os.environ.get("PG__PASSWORD", "postgres"),
+    )
+
+
+def get_concept_count(conn, vocab_schema):
+    """Get total concept count for progress bar."""
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT COUNT(*) FROM {vocab_schema}.concept")
+        return cur.fetchone()[0]
+
+
+def extract_concepts(conn, vocab_schema):
+    """Extract concepts using a server-side cursor for memory efficiency."""
+    cursor = conn.cursor(
+        name="concept_cursor", cursor_factory=psycopg2.extras.RealDictCursor
+    )
+    cursor.itersize = BATCH_SIZE
+    query = f"""
+        SELECT concept_id, concept_name, domain_id, vocabulary_id,
+               concept_class_id, standard_concept, concept_code,
+               invalid_reason, valid_start_date, valid_end_date
+        FROM {vocab_schema}.concept
+    """
+    cursor.execute(query)
+    return cursor
+
+
+def load_record_counts():
+    """Load record counts from the same JSON file the Rust API uses."""
+    path = os.environ.get(
+        "RECORD_COUNTS_PATH",
+        os.path.join(os.path.dirname(__file__), "..", "api", "ConceptRecordCounts.json"),
+    )
+    path = os.path.abspath(path)
+    if os.path.exists(path):
+        with open(path) as f:
+            data = json.load(f)
+        print(f"Loaded {len(data)} record counts from {path}")
+        return data
+    print(f"No record counts file found at {path}, using empty counts")
+    return {}
+
+
+def transform_concept(row, record_counts):
+    """Transform a PostgreSQL row to a Solr document."""
+    doc = dict(row)
+
+    # Convert dates to Solr ISO 8601 format
+    for date_field in ("valid_start_date", "valid_end_date"):
+        val = doc.get(date_field)
+        if val and isinstance(val, (date, datetime)):
+            doc[date_field] = val.isoformat() + "T00:00:00Z"
+        elif val is None:
+            del doc[date_field]
+
+    # Replace None with empty string for string fields
+    doc["standard_concept"] = doc.get("standard_concept") or ""
+    doc["invalid_reason"] = doc.get("invalid_reason") or ""
+
+    # Enrich with record count
+    doc["record_count"] = record_counts.get(str(doc["concept_id"]), 0)
+
+    return doc
+
+
+def load_to_solr(docs, solr_url):
+    """POST a batch of documents to Solr."""
+    response = requests.post(
+        f"{solr_url}/update/json/docs?commit=false",
+        json=docs,
+        headers={"Content-Type": "application/json"},
+        timeout=120,
+    )
+    response.raise_for_status()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Load OMOP vocabulary concepts from PostgreSQL into Apache Solr"
+    )
+    parser.add_argument(
+        "--clear",
+        action="store_true",
+        help="Delete all existing documents before loading",
+    )
+    parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        help="Skip final commit (useful if loading in stages)",
+    )
+    args = parser.parse_args()
+
+    vocab_schema = os.environ.get("VOCAB_SCHEMA")
+    if not vocab_schema:
+        sys.exit("Error: VOCAB_SCHEMA environment variable must be set")
+
+    solr_url = SOLR_URL
+    print(f"Solr URL: {solr_url}")
+    print(f"Vocabulary schema: {vocab_schema}")
+
+    # Verify Solr is reachable
+    try:
+        resp = requests.get(f"{solr_url}/admin/ping", timeout=10)
+        resp.raise_for_status()
+        print("Solr ping: OK")
+    except requests.RequestException as e:
+        sys.exit(f"Error: Cannot reach Solr at {solr_url}: {e}")
+
+    if args.clear:
+        print("Clearing existing documents...")
+        requests.post(
+            f"{solr_url}/update",
+            json={"delete": {"query": "*:*"}},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        requests.get(f"{solr_url}/update?commit=true", timeout=30)
+        print("Cleared.")
+
+    record_counts = load_record_counts()
+
+    conn = get_pg_connection()
+    total_count = get_concept_count(conn, vocab_schema)
+    print(f"Total concepts to load: {total_count}")
+
+    cursor = extract_concepts(conn, vocab_schema)
+
+    total_loaded = 0
+    batch = []
+
+    with tqdm(total=total_count, unit="concepts") as pbar:
+        for row in cursor:
+            batch.append(transform_concept(row, record_counts))
+            if len(batch) >= BATCH_SIZE:
+                load_to_solr(batch, solr_url)
+                total_loaded += len(batch)
+                pbar.update(len(batch))
+                batch = []
+
+        if batch:
+            load_to_solr(batch, solr_url)
+            total_loaded += len(batch)
+            pbar.update(len(batch))
+
+    if not args.no_commit:
+        print("Committing...")
+        requests.get(f"{solr_url}/update?commit=true", timeout=120)
+
+    print(f"Done. Total concepts loaded: {total_loaded}")
+    cursor.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "axios": "^1.13.5",
+        "axios": "^1.13.6",
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.5",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -576,9 +576,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/mcp/src/api-client.ts
+++ b/mcp/src/api-client.ts
@@ -49,6 +49,31 @@ export class HecateApiClient {
     return response.data;
   }
 
+  async searchLexical(query: string, options?: SearchOptions): Promise<SearchResponse[]> {
+    const params = new URLSearchParams({ q: query });
+
+    if (options?.vocabulary_id) {
+      params.append('vocabulary_id', options.vocabulary_id);
+    }
+    if (options?.standard_concept !== undefined) {
+      params.append('standard_concept', options.standard_concept);
+    }
+    if (options?.domain_id) {
+      params.append('domain_id', options.domain_id);
+    }
+    if (options?.concept_class_id) {
+      params.append('concept_class_id', options.concept_class_id);
+    }
+    if (options?.limit) {
+      params.append('limit', options.limit.toString());
+    }
+
+    const response: AxiosResponse<SearchResponse[]> = await this.client.get(
+      `/search_lexical?${params.toString()}`,
+    );
+    return response.data;
+  }
+
   async getConceptById(id: number): Promise<Concept> {
     const response: AxiosResponse<Concept[]> = await this.client.get(
       `/concepts/${id}`,

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -104,6 +104,46 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "search_concepts_lexical",
+        description:
+          "Search for OMOP Standardized Vocabulary concepts using lexical (keyword) search powered by Apache Solr. Unlike semantic search, this performs exact and fuzzy text matching against concept names and codes. Best for searching by exact concept codes (like ICD-10 codes), known concept names, or when semantic similarity is not desired. Supports medical synonym expansion.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description:
+                "Search query for medical concepts. Can search by concept name, ID, or code. Examples: 'diabetes', 'hypertension', '4321435', 'E11.9'.",
+              minLength: 1,
+              maxLength: 500,
+            },
+            vocabulary_id: {
+              type: "string",
+              description: "Filter by vocabulary source. Common vocabularies: 'SNOMED', 'ICD10CM', 'RxNorm', 'LOINC', 'CPT4', 'HCPCS', 'MedDRA'.",
+            },
+            standard_concept: {
+              type: "string",
+              description: "Filter by standardization status: 'S' = Standard concepts, 'C' = Classification concepts, empty/null = Non-standard source concepts.",
+            },
+            domain_id: {
+              type: "string",
+              description: "Filter by clinical domain: 'Condition', 'Drug', 'Procedure', 'Measurement', 'Observation', 'Device', 'Visit'.",
+            },
+            concept_class_id: {
+              type: "string",
+              description: "Filter by concept classification within vocabulary. Examples: 'Clinical Finding', 'Ingredient', 'Procedure', 'Lab Test'.",
+            },
+            limit: {
+              type: "number",
+              description: "Maximum number of results to return (default: 25, max: 999)",
+              minimum: 1,
+              maximum: 999,
+            },
+          },
+          required: ["query"],
+        },
+      },
+      {
         name: "get_concept_by_id",
         description:
           "Get detailed information about a specific OMOP concept by its unique concept ID. Returns concept metadata including name, domain, vocabulary, concept class, and validity dates.",
@@ -202,6 +242,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: JSON.stringify(results, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "search_concepts_lexical": {
+        const { query, vocabulary_id, standard_concept, domain_id, concept_class_id, limit = 25 } = SearchInputSchema.parse(args);
+        const lexicalResults = await apiClient.searchLexical(query, {
+          vocabulary_id,
+          standard_concept,
+          domain_id,
+          concept_class_id,
+          limit,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(lexicalResults, null, 2),
             },
           ],
         };

--- a/solr/README.md
+++ b/solr/README.md
@@ -1,0 +1,144 @@
+# Solr Lexical Search Setup
+
+Hecate supports an optional Apache Solr-based lexical search alongside the primary semantic (vector) search. Lexical search is better for exact concept codes (ICD-10, SNOMED codes), known concept names, and keyword-based queries.
+
+**This component is optional.** The API starts and functions normally without Solr. The `/api/search_lexical` endpoint returns `503 Service Unavailable` when Solr is not configured.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Python 3.8+ (for the ETL script)
+- A running PostgreSQL instance with the OMOP vocabulary loaded
+
+## Quick Start
+
+### 1. Start Solr
+
+From the repository root:
+
+```bash
+docker compose up -d
+```
+
+This starts Solr 9.8 on port 8983 and creates the `omop_concepts` core with the pre-configured schema.
+
+Verify Solr is running:
+
+```bash
+curl http://localhost:8983/solr/omop_concepts/admin/ping
+```
+
+### 2. Load Vocabulary into Solr
+
+Install Python dependencies:
+
+```bash
+cd etl
+pip install -r requirements.txt
+```
+
+Run the ETL script. The script reads from the same PostgreSQL database used by the API, using the same environment variables:
+
+```bash
+export PG__HOST=127.0.0.1
+export PG__PORT=5432
+export PG__DBNAME=hecate
+export PG__USER=postgres
+export PG__PASSWORD=postgres
+export VOCAB_SCHEMA=vocab_27_feb_2026
+
+python solr_load.py --clear
+```
+
+This streams all concepts from PostgreSQL into Solr in batches of 5000. For ~7M concepts, expect a few minutes. Progress is displayed via a progress bar.
+
+Options:
+- `--clear` removes all existing documents before loading
+- `--no-commit` skips the final commit (useful for staged loading)
+
+The script also enriches concepts with record counts from `api/ConceptRecordCounts.json` if available.
+
+### 3. Configure the API
+
+Add the Solr URL to your `.env` file:
+
+```bash
+SOLR_URL=http://localhost:8983/solr/omop_concepts
+```
+
+If `SOLR_URL` is not set, the API starts normally with lexical search disabled.
+
+### 4. Test
+
+```bash
+# Lexical search
+curl "http://localhost:8080/api/search_lexical?q=diabetes&limit=5"
+
+# Search by exact concept code
+curl "http://localhost:8080/api/search_lexical?q=E11.9"
+
+# With filters
+curl "http://localhost:8080/api/search_lexical?q=hypertension&vocabulary_id=SNOMED&domain_id=Condition"
+```
+
+## Solr Schema
+
+The schema is defined in `solr/configsets/omop_concepts/conf/managed-schema.xml` and includes:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `concept_id` | pint (uniqueKey) | OMOP concept ID |
+| `concept_name` | text_medical | Full-text search with medical text analysis |
+| `concept_name_edge` | text_edge_ngram | Prefix/autocomplete matching (copy field) |
+| `concept_name_exact` | string | Exact match boosting (copy field) |
+| `concept_code` | string | Vocabulary-specific code (e.g., ICD-10 code) |
+| `domain_id` | string | Clinical domain filter |
+| `vocabulary_id` | string | Vocabulary source filter |
+| `concept_class_id` | string | Concept classification filter |
+| `standard_concept` | string | Standardization status filter |
+| `record_count` | plong | Usage frequency in the OHDSI network |
+
+### Text Analysis
+
+The `text_medical` field type uses:
+- Whitespace tokenizer
+- Word delimiter graph filter (splits `acetyl-salicylic` into tokens, preserves original)
+- ASCII folding (handles accented characters in European drug names)
+- English minimal stemmer (light stemming appropriate for medical terms)
+- Medical synonym expansion at query time (e.g., MI -> myocardial infarction)
+
+### Query Configuration
+
+Uses the eDisMax query parser with field boosting:
+- `concept_name_exact^10` - exact name match highest priority
+- `concept_code^8` - code matches high priority
+- `concept_name^5` - analyzed text match
+- `concept_name_edge^1` - prefix matches lowest priority
+- Phrase boosting: `concept_name^10`
+- Minimum match: 75% of query terms
+
+## Medical Synonyms
+
+Common medical abbreviations are expanded at query time via `solr/configsets/omop_concepts/conf/medical_synonyms.txt`. Add additional synonyms as needed in the format:
+
+```
+ABBREVIATION, full term
+```
+
+After modifying synonyms, reload the Solr core:
+
+```bash
+curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=omop_concepts"
+```
+
+## Architecture
+
+```
+PostgreSQL (OMOP vocab) ──ETL──> Apache Solr (lexical index)
+                                        │
+                                        ▼
+Hecate API ──/api/search_lexical──> Solr REST API
+         └──/api/search──────────> Qdrant (semantic)
+```
+
+The lexical and semantic search endpoints are independent. Clients can query either or both and merge results as needed.

--- a/solr/configsets/omop_concepts/conf/managed-schema.xml
+++ b/solr/configsets/omop_concepts/conf/managed-schema.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="omop_concepts" version="1.6">
+
+  <!-- Field types -->
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true"/>
+  <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+  <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+  <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+
+  <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
+    <analyzer>
+      <tokenizer class="solr.KeywordTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- Medical text analysis: whitespace + word splitting + light stemming -->
+  <fieldType name="text_medical" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory"
+              generateWordParts="1" generateNumberParts="1"
+              catenateWords="1" catenateNumbers="0"
+              splitOnCaseChange="1" splitOnNumerics="0"
+              preserveOriginal="1"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.ASCIIFoldingFilterFactory"/>
+      <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory"
+              generateWordParts="1" generateNumberParts="1"
+              catenateWords="0" catenateNumbers="0"
+              splitOnCaseChange="1" splitOnNumerics="0"
+              preserveOriginal="1"/>
+      <filter class="solr.SynonymGraphFilterFactory"
+              synonyms="medical_synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.ASCIIFoldingFilterFactory"/>
+      <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- Edge ngram for prefix/autocomplete matching -->
+  <fieldType name="text_edge_ngram" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="25"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- Fields -->
+  <uniqueKey>concept_id</uniqueKey>
+
+  <field name="concept_id" type="pint" indexed="true" stored="true" required="true"/>
+  <field name="concept_name" type="text_medical" indexed="true" stored="true"/>
+  <field name="concept_name_edge" type="text_edge_ngram" indexed="true" stored="false"/>
+  <field name="concept_name_exact" type="string" indexed="true" stored="false"/>
+  <field name="concept_name_lower" type="lowercase" indexed="true" stored="true"/>
+  <field name="domain_id" type="string" indexed="true" stored="true"/>
+  <field name="vocabulary_id" type="string" indexed="true" stored="true"/>
+  <field name="concept_class_id" type="string" indexed="true" stored="true"/>
+  <field name="standard_concept" type="string" indexed="true" stored="true"/>
+  <field name="concept_code" type="string" indexed="true" stored="true"/>
+  <field name="invalid_reason" type="string" indexed="true" stored="true"/>
+  <field name="valid_start_date" type="pdate" indexed="true" stored="true"/>
+  <field name="valid_end_date" type="pdate" indexed="true" stored="true"/>
+  <field name="record_count" type="plong" indexed="true" stored="true" default="0"/>
+
+  <!-- Copy fields for multi-analysis -->
+  <copyField source="concept_name" dest="concept_name_edge"/>
+  <copyField source="concept_name" dest="concept_name_exact"/>
+  <copyField source="concept_name" dest="concept_name_lower"/>
+
+</schema>

--- a/solr/configsets/omop_concepts/conf/medical_synonyms.txt
+++ b/solr/configsets/omop_concepts/conf/medical_synonyms.txt
@@ -1,0 +1,27 @@
+# Medical abbreviation synonyms for Solr query expansion
+# Format: abbreviation, full term (bidirectional expansion)
+MI, myocardial infarction
+DM, diabetes mellitus
+HTN, hypertension
+COPD, chronic obstructive pulmonary disease
+CHF, congestive heart failure
+CKD, chronic kidney disease
+DVT, deep vein thrombosis
+PE, pulmonary embolism
+UTI, urinary tract infection
+CAD, coronary artery disease
+AFib, atrial fibrillation
+T2DM, type 2 diabetes mellitus
+T1DM, type 1 diabetes mellitus
+NSAID, nonsteroidal anti-inflammatory drug
+ACE, angiotensin converting enzyme
+GERD, gastroesophageal reflux disease
+AKI, acute kidney injury
+ARDS, acute respiratory distress syndrome
+TIA, transient ischemic attack
+CVA, cerebrovascular accident
+RA, rheumatoid arthritis
+SLE, systemic lupus erythematosus
+MS, multiple sclerosis
+IBD, inflammatory bowel disease
+ESRD, end stage renal disease

--- a/solr/configsets/omop_concepts/conf/solrconfig.xml
+++ b/solr/configsets/omop_concepts/conf/solrconfig.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config>
+  <luceneMatchVersion>9.8</luceneMatchVersion>
+
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <autoCommit>
+      <maxTime>60000</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+    <autoSoftCommit>
+      <maxTime>15000</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
+  <query>
+    <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
+    <filterCache class="solr.CaffeineCache" size="512" initialSize="128" autowarmCount="64"/>
+    <queryResultCache class="solr.CaffeineCache" size="512" initialSize="128" autowarmCount="64"/>
+    <documentCache class="solr.CaffeineCache" size="512" initialSize="128" autowarmCount="0"/>
+  </query>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="wt">json</str>
+      <str name="defType">edismax</str>
+      <str name="qf">concept_name_exact^10 concept_name^5 concept_name_edge^1 concept_code^8</str>
+      <str name="pf">concept_name^10</str>
+      <str name="mm">75%</str>
+      <int name="rows">25</int>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"/>
+
+  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+    <lst name="invariants">
+      <str name="q">*:*</str>
+    </lst>
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+    </lst>
+  </requestHandler>
+
+  <requestDispatcher>
+    <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="-1"/>
+    <httpCaching never304="true"/>
+  </requestDispatcher>
+
+</config>


### PR DESCRIPTION
Add keyword-based lexical search as a complement to the existing semantic (vector) search. Solr is optional — the API starts normally without it and the /api/search_lexical endpoint returns 503 when Solr is not configured.

- Docker Compose config for Solr 9.8 with medical text analysis schema
- Python ETL script to load OMOP vocabulary from PostgreSQL into Solr
- Rust Solr client module and /api/search_lexical API endpoint
- MCP server search_concepts_lexical tool
- OpenAPI spec and setup documentation

@RowanErasmus 